### PR TITLE
About 10k+ Problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ configurations {
     provided
 }
 
-version = "0.1.0"
+version = "0.1.1"
 [compileJava, compileTestJava]*.options*.encoding = "UTF-8"
 
 dependencies {
-    compile 'com.force.api:force-wsc:34.+'
-    compile 'com.force.api:force-partner-api:34.+'
+    compile 'com.force.api:force-wsc:38.+'
+    compile 'com.force.api:force-partner-api:38.+'
     compile  "org.embulk:embulk-core:0.7.3"
     provided "org.embulk:embulk-core:0.7.3"
     testCompile "junit:junit:4.+"

--- a/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkWrapper.java
+++ b/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkWrapper.java
@@ -141,7 +141,7 @@ public class SalesforceBulkWrapper implements AutoCloseable {
                             batchInfo.getJobId(),
                             batchInfo.getId(),
                             queryResultId));
-
+	    rdr.setMaxRowsInFile(2147483647);
             List<String> resultHeader = rdr.nextRecord();
             int resultCols = resultHeader.size();
 


### PR DESCRIPTION
https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_concepts_limits.htm

こちらの問題がでていました。

SalesForceを最新の38.0系に切り替え
Raw10k+問題が出ていたので、int値の最上限に設定。
バージョンを0.1.1にup
