### PR TITLE
Add queryall

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ in:
   type: salesforce_bulk
   userName: USER_NAME
   password: PASSWORD
-  authEndpointUrl: https://login.salesforce.com/services/Soap/u/34.0
+  authEndpointUrl: https://login.salesforce.com/services/Soap/u/39.0
   objectType: Account
   pollingIntervalMillisecond: 5000
   querySelectFrom: SELECT Id,Name,LastModifiedDate FROM Account
@@ -56,7 +56,7 @@ in:
   type: salesforce_bulk
   userName: USER_NAME
   password: PASSWORD
-  authEndpointUrl: https://login.salesforce.com/services/Soap/u/34.0
+  authEndpointUrl: https://login.salesforce.com/services/Soap/u/39.0
   objectType: Account
   pollingIntervalMillisecond: 5000
   querySelectFrom: SELECT Id,Name,LastModifiedDate FROM Account

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Salesforce Bulk API の一括クエリ結果を取得します。
 - **columns**: schema config.(SchemaConfig, required)
 - **startRowMarkerName**: 開始レコードを特定するための目印とするカラム名を指定する.(String, default is null)
 - **start_row_marker**: 抽出条件に、『カラム「startRowMarkerName」がこの値よりも大きい』を追加する.(string, default is null)
+- **queryAll**: if true, uses the queryAll operation so that deleted records are returned.(boolean, default is false)
 
 ## Example
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.1.1"
+version = "0.2.0"
 [compileJava, compileTestJava]*.options*.encoding = "UTF-8"
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ version = "0.1.1"
 [compileJava, compileTestJava]*.options*.encoding = "UTF-8"
 
 dependencies {
-    compile 'com.force.api:force-wsc:38.+'
-    compile 'com.force.api:force-partner-api:38.+'
+    compile 'com.force.api:force-wsc:39.+'
+    compile 'com.force.api:force-partner-api:39.+'
     compile  "org.embulk:embulk-core:0.8.14"
     provided "org.embulk:embulk-core:0.8.14"
     testCompile "junit:junit:4.+"

--- a/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkInputPlugin.java
+++ b/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkInputPlugin.java
@@ -103,6 +103,10 @@ public class SalesforceBulkInputPlugin
         // 謎。バッファアロケーターの実装を定義？
         @ConfigInject
         public BufferAllocator getBufferAllocator();
+
+        @Config("queryAll")
+        @ConfigDefault("false")
+        public Boolean getQueryAll();
     }
 
     private Logger log = Exec.getLogger(SalesforceBulkInputPlugin.class);
@@ -167,7 +171,8 @@ public class SalesforceBulkInputPlugin
                 task.getPassword(),
                 task.getAuthEndpointUrl(),
                 task.getCompression(),
-                task.getPollingIntervalMillisecond())) {
+                task.getPollingIntervalMillisecond(),
+                task.getQueryAll())) {
 
             log.info("Login success.");
 

--- a/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkWrapper.java
+++ b/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkWrapper.java
@@ -54,7 +54,7 @@ public class SalesforceBulkWrapper implements AutoCloseable {
     private boolean isCompression;
     private int pollingIntervalMillisecond;
 
-    private static final String API_VERSION = "34.0";
+    private static final String API_VERSION = "39.0";
     private static final String AUTH_ENDPOINT_URL_DEFAULT =
             "https://login.salesforce.com/services/Soap/u/" + API_VERSION;
 

--- a/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkWrapper.java
+++ b/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkWrapper.java
@@ -53,6 +53,7 @@ public class SalesforceBulkWrapper implements AutoCloseable {
     // Bulk 接続設定
     private boolean isCompression;
     private int pollingIntervalMillisecond;
+    private boolean queryAll;
 
     private static final String API_VERSION = "39.0";
     private static final String AUTH_ENDPOINT_URL_DEFAULT =
@@ -60,6 +61,7 @@ public class SalesforceBulkWrapper implements AutoCloseable {
 
     private static final boolean IS_COMPRESSION_DEFAULT = true;
     private static final int POLLING_INTERVAL_MILLISECOND_DEFAULT = 30000;
+    private static final boolean QUERY_ALL_DEFAULT = false;
 
     /**
      * Constructor
@@ -70,7 +72,8 @@ public class SalesforceBulkWrapper implements AutoCloseable {
                 password,
                 AUTH_ENDPOINT_URL_DEFAULT,
                 IS_COMPRESSION_DEFAULT,
-                POLLING_INTERVAL_MILLISECOND_DEFAULT);
+                POLLING_INTERVAL_MILLISECOND_DEFAULT,
+                QUERY_ALL_DEFAULT);
     }
 
     /**
@@ -81,7 +84,8 @@ public class SalesforceBulkWrapper implements AutoCloseable {
             String password,
             String authEndpointUrl,
             boolean isCompression,
-            int pollingIntervalMillisecond)
+            int pollingIntervalMillisecond,
+            boolean queryAll)
             throws AsyncApiException, ConnectionException {
 
         partnerConnection = createPartnerConnection(
@@ -91,6 +95,7 @@ public class SalesforceBulkWrapper implements AutoCloseable {
         bulkConnection = createBulkConnection(partnerConnection.getConfig());
 
         this.pollingIntervalMillisecond = pollingIntervalMillisecond;
+        this.queryAll = queryAll;
     }
 
     public List<Map<String, String>> syncQuery(String objectType, String query)
@@ -99,7 +104,11 @@ public class SalesforceBulkWrapper implements AutoCloseable {
         // ジョブ作成
         JobInfo jobInfo = new JobInfo();
         jobInfo.setObject(objectType);
-        jobInfo.setOperation(OperationEnum.query);
+        if (queryAll) {
+            jobInfo.setOperation(OperationEnum.queryAll);
+        } else {
+            jobInfo.setOperation(OperationEnum.query);
+        }
         jobInfo.setContentType(ContentType.CSV);
         jobInfo = bulkConnection.createJob(jobInfo);
 


### PR DESCRIPTION
Version 39 of the Salesforce Bulk API added support for the `queryAll` operation, which returns records that have been deleted. Here I add support for that operation.