### PR TITLE
Change authEndpointUrl default to a URL that works

### DIFF
--- a/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkInputPlugin.java
+++ b/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkInputPlugin.java
@@ -47,7 +47,7 @@ public class SalesforceBulkInputPlugin
     {
         // 認証用エンドポイントURL
         @Config("authEndpointUrl")
-        @ConfigDefault("http://login.salesforce.com/")
+        @ConfigDefault("https://login.salesforce.com/services/Soap/u/39.0")
         public String getAuthEndpointUrl();
 
         // ユーザー名


### PR DESCRIPTION
Small change to the default `authEndpointUrl`. I don't think the other default is valid.