### PR TITLE
Abort when salesforce wrapper error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.2.2"
+version = "0.2.3"
 [compileJava, compileTestJava]*.options*.encoding = "UTF-8"
 
 dependencies {

--- a/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkInputPlugin.java
+++ b/src/main/java/org/embulk/input/salesforce_bulk/SalesforceBulkInputPlugin.java
@@ -237,6 +237,7 @@ public class SalesforceBulkInputPlugin
             }
         } catch (ConnectionException|AsyncApiException|InterruptedException|IOException e) {
             log.error("{}", e.getClass(), e);
+            throw new RuntimeException("SalesforceBulkWrapperError");
         }
 
         return taskReport;


### PR DESCRIPTION
This input plugin succeeded with exit code `0` even if Salesforce API error with empty data. I changed to abort when an error occurred.